### PR TITLE
Replace raise with return

### DIFF
--- a/lib/bitmap.rb
+++ b/lib/bitmap.rb
@@ -3,7 +3,6 @@ class Bitmap
   MAX_HEIGHT = 250
   WHITE = 'O'
 
-
   def create(m, n = nil)
     if n.nil?
       @matrix = m.split("\n").map { |x| x.split('') }
@@ -76,7 +75,7 @@ class Bitmap
   end
 
   def show
-    validate
+    return 'There is no image' unless defined?(@matrix)
     @matrix.map{|n| n.join('') }.join("\n")
   end
 

--- a/lib/bitmap.rb
+++ b/lib/bitmap.rb
@@ -13,8 +13,8 @@ class Bitmap
       @n = n.to_i
     end
 
-    raise "M must be in the range 1 to #{MAX_WIDTH}" if @m < 1 || @m > MAX_WIDTH
-    raise "N must be in the range 1 to #{MAX_HEIGHT}" if @n < 1 || @n > MAX_HEIGHT
+    return "M must be in the range 1 to #{MAX_WIDTH}" if @m < 1 || @m > MAX_WIDTH
+    return "N must be in the range 1 to #{MAX_HEIGHT}" if @n < 1 || @n > MAX_HEIGHT
 
     clear unless defined?(@matrix)
     nil
@@ -26,12 +26,12 @@ class Bitmap
   end
 
   def apply(x, y, colour)
-    validate
+    return 'There is no image' unless defined?(@matrix)
     x = x.to_i
     y = y.to_i
-    raise "X must be in the range 1 to #{@m}" if x < 1 || x > @m
-    raise "Y must be in the range 1 to #{@n}" if y < 1 || y > @n
-    raise "C must be in the range A to Z" unless ('A'..'Z').include? colour
+    return "X must be in the range 1 to #{@m}" if x < 1 || x > @m
+    return "Y must be in the range 1 to #{@n}" if y < 1 || y > @n
+    return "C must be in the range A to Z" unless ('A'..'Z').include? colour
 
     set(x, y, colour)
     nil
@@ -43,7 +43,8 @@ class Bitmap
     y2 = y2.to_i
 
     (y1..y2).each do |y|
-      apply(x, y, colour)
+      output = apply(x, y, colour)
+      return output if output
     end
     nil
   end
@@ -54,7 +55,8 @@ class Bitmap
     y = y.to_i
 
     (x1..x2).each do |x|
-      apply(x, y, colour)
+      output = apply(x, y, colour)
+      return output if output
     end
     nil
   end
@@ -87,9 +89,5 @@ class Bitmap
 
   def get(x, y)
     @matrix[y - 1][x - 1]
-  end
-
-  def validate
-    raise 'There is no image' unless defined?(@matrix)
   end
 end

--- a/lib/bitmap_editor.rb
+++ b/lib/bitmap_editor.rb
@@ -8,13 +8,13 @@ class BitmapEditor
   end
 
   def run(file, kernel = Kernel)
-    raise "please provide correct file" unless file && File.exist?(file)
+    return kernel.puts "Please provide correct file" unless file && File.exist?(file)
 
+    output = nil
     File.open(file).each do |line|
       output = @processor.call(line.chomp)
-      kernel.puts output if output
+      break if output.is_a? String
     end
-  rescue => e
-    kernel.puts e.message
+    kernel.puts output || 'Show never called'
   end
 end

--- a/lib/command_processor.rb
+++ b/lib/command_processor.rb
@@ -18,7 +18,7 @@ class CommandProcessor
   def call(params)
     args = params.split(' ')
     method = COMMANDS[args.shift]
-    raise 'unrecognised command :(' unless method
+    return 'unrecognised command :(' unless method
     @bitmap.send(method, *args)
   end
 end

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Bitmap do
     end
 
     it 'errors when not created' do
-      expect{ described_class.new.show }.to raise_error('There is no image')
+      expect(described_class.new.show).to eq('There is no image')
     end
   end
 end

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -10,25 +10,25 @@ RSpec.describe Bitmap do
     end
 
     it 'errors when width is too small' do
-      expect{ subject.create('0', '1') }.to raise_error(
+      expect(subject.create('0', '1')).to eq(
         "M must be in the range 1 to #{Bitmap::MAX_WIDTH}"
       )
     end
 
     it 'errors when height is too small' do
-      expect{ subject.create('1', '0') }.to raise_error(
+      expect(subject.create('1', '0')).to eq(
         "N must be in the range 1 to #{Bitmap::MAX_HEIGHT}"
       )
     end
 
     it 'errors when M is too large' do
-      expect{ subject.create(Bitmap::MAX_WIDTH + 1, '1') }.to raise_error(
+      expect(subject.create(Bitmap::MAX_WIDTH + 1, '1')).to eq(
         "M must be in the range 1 to #{Bitmap::MAX_WIDTH}"
       )
     end
 
     it 'errors when N is too large' do
-      expect{ subject.create('1', Bitmap::MAX_HEIGHT + 1) }.to raise_error(
+      expect(subject.create('1', Bitmap::MAX_HEIGHT + 1)).to eq(
         "N must be in the range 1 to #{Bitmap::MAX_HEIGHT}"
       )
     end
@@ -110,34 +110,34 @@ RSpec.describe Bitmap do
     end
 
     it 'errors when C is not a letter' do
-      expect{ subject.apply('1', '1', '1') }.to raise_error(
+      expect(subject.apply('1', '1', '1')).to eq(
         'C must be in the range A to Z'
       )
-      expect{ subject.apply('1', '1', 'a') }.to raise_error(
+      expect(subject.apply('1', '1', 'a')).to eq(
         'C must be in the range A to Z'
       )
     end
 
     it 'errors when X is less than 1' do
-      expect{ subject.apply('0', '1', nil) }.to raise_error(
+      expect(subject.apply('0', '1', nil)).to eq(
         'X must be in the range 1 to 4'
       )
     end
 
     it 'errors when Y is less than 1' do
-      expect{ subject.apply('1', '0', nil) }.to raise_error(
+      expect(subject.apply('1', '0', nil)).to eq(
         'Y must be in the range 1 to 2'
       )
     end
 
     it 'errors when X is greater than width' do
-      expect{ subject.apply('5', '1', nil) }.to raise_error(
+      expect(subject.apply('5', '1', nil)).to eq(
         'X must be in the range 1 to 4'
       )
     end
 
     it 'errors when Y is greater than height' do
-      expect{ subject.apply('1', '3', nil) }.to raise_error(
+      expect(subject.apply('1', '3', nil)).to eq(
         'Y must be in the range 1 to 2'
       )
     end
@@ -156,7 +156,7 @@ RSpec.describe Bitmap do
     end
 
     it 'errors when coordinate is out of range' do
-      expect{ subject.vertical('0', '1', '2', nil) }.to raise_error(
+      expect(subject.vertical('0', '1', '2', nil)).to eq(
         'X must be in the range 1 to 4'
       )
     end
@@ -171,7 +171,7 @@ RSpec.describe Bitmap do
     end
 
     it 'errors when coordinate is out of range' do
-      expect{ subject.horizontal('0', '1', '2', nil) }.to raise_error(
+      expect(subject.horizontal('0', '1', '2', nil)).to eq(
         'X must be in the range 1 to 4'
       )
     end

--- a/spec/command_processor_spec.rb
+++ b/spec/command_processor_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CommandProcessor do
 
   context 'when unknown command' do
     it 'errors' do
-      expect{ subject.call('') }.to raise_error 'unrecognised command :('
+      expect(subject.call('')).to eq 'unrecognised command :('
     end
   end
 

--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -21,10 +21,17 @@ RSpec.describe BitmapEditor do
     end
   end
 
+  context 'when show not called' do
+    it 'returns error message' do
+      subject.run File.join(__dir__, '../examples/no_show.txt'), kernel
+      expect(kernel).to have_received(:puts).with 'Show never called'
+    end
+  end
+
   context 'when no file' do
     it 'returns instruction' do
       subject.run 'bla.txt', kernel
-      expect(kernel).to have_received(:puts).with 'please provide correct file'
+      expect(kernel).to have_received(:puts).with 'Please provide correct file'
     end
   end
 


### PR DESCRIPTION
These messages are related to user input and don't feel like exceptional cases so this PR replaces them with early returns carrying the instructional message. 

It's a little clunky at the moment (having to pass it back down the call chain) but further refactoring should clean things up.